### PR TITLE
Prepare release 1.0.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-09-13
+## 1.0.0 - 2021-11-22
 
 ### Added
 


### PR DESCRIPTION
Hello, there have been user changing changes merged in the past couple of months which should be released.

As discussed earlier, this product has been released, and should already be 1.x.x rather than a prerelease 0.x.x, so the next release should be 1.0.0.

The user-facing changes include:

- fix: search is retained when switching between data/preview tab, and when using the "Load more" button (PTV-1694)
- improvement: ensure that the naming of itself is Narratives Navigator, or Navigator for short, and that the button is consistent with kbase-ui (SCT-2971)
